### PR TITLE
feat: add graph visualization with graphviz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,13 @@ poetry.lock
 .vscode/
 mlruns/
 *plots/
+*.dot
+*.pdf
+*.svg
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.bmp
+*.tiff
+*.ico

--- a/examples/rl_pipeline.py
+++ b/examples/rl_pipeline.py
@@ -1,4 +1,4 @@
-from regelum.environment.node.base import Node, State, Inputs, Graph
+from regelum.environment.node.base import Node, State, Inputs, Graph, visualize_graph
 from regelum.environment.node.continuous import Pendulum
 from typing import Dict, Any
 import numpy as np
@@ -542,5 +542,6 @@ graph = Graph(
     # logger_cooldown=0.0,
 )
 
+visualize_graph(graph, output_file="rl_pipeline", view=False)
 for _ in range(total_timesteps):
     graph.step()

--- a/regelum/environment/transistor.py
+++ b/regelum/environment/transistor.py
@@ -519,6 +519,8 @@ class SampleAndHoldModifier(TransistorModifier):
         class SampleAndHoldTransistor(transistor_cls):
             """A transistor class modified with sample-and-hold behavior."""
 
+            is_modifier = True
+
             def __init__(self, node, time_final: Optional[float] = None):
                 super().__init__(node=node, time_final=time_final)
                 self.last_update_time = None
@@ -562,6 +564,8 @@ class ResetModifier(TransistorModifier):
 
         class ResetTransistor(transistor_cls):
             """A transistor class modified with reset behavior."""
+
+            is_modifier = True
 
             def __init__(self, node, time_final: Optional[float] = None):
                 super().__init__(node=node, time_final=time_final)


### PR DESCRIPTION
- Add visualize_graph function to create block diagrams of node graphs
- Add transistor modifier flags for proper visualization
- Update gitignore to exclude generated graph files
- Move visualization import to top of rl_pipeline example